### PR TITLE
Grab more Facebook fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,39 @@ module.exports.waterlock = {
 }
 ```
 
+### Grabbing Facebook field values
 
+By default, waterlock-facebook-auth stores the user's `facebookId`, `name` and `email` in the Auth model. In reality, Facebook returns more data than that. 
 
+To grab and store this, you will need to modify the add the fields in your `Auth.js` model...
+
+```js
+// api/models/Auth.js
+module.exports = {
+	attributes: require('waterlock').models.auth.attributes({
+		firstName: 'string',
+		lastName: 'string',
+		gender: 'string',
+		timezone: 'number'
+	})
+}
+```
+
+...and then add a `fieldMap` object within the facebook authMethod in your `waterlock.js` config file which matches your model's fields to facebook's fields.
+
+```js
+authMethod: [
+	{
+		name: "waterlock-facebook-auth",
+		appId: "your-app-id",
+		appSecret: "your-app-secret",
+		fieldMap: {
+			// <model-field>: <facebook-field>,
+			'firstName': 'first_name',
+			'lastName': 'last_name',
+			'gender': 'gender',
+			'timezone': 'timezone'
+		}
+	}
+]
+```

--- a/lib/controllers/actions/oauth2.js
+++ b/lib/controllers/actions/oauth2.js
@@ -1,5 +1,8 @@
 'use strict';
 
+var _ = require('lodash');
+
+var authConfig = require('../../waterlock-facebook-auth').authConfig;
 var fb = require('../../waterlock-facebook-auth').fb;
 
 /**
@@ -46,7 +49,14 @@ module.exports = function (req, res){
         facebookId: _data.id,
         name: _data.name
       };
-      
+
+      var fieldMap = authConfig.fieldMap || {};
+
+      _.each(fieldMap, function(val, key) {
+        if (!_.isUndefined(_data[val])) {
+          attr[key] = _data[val];
+        }
+      });
 
       if(req.session.authenticated){
         attr['user'] = req.session.user.id;

--- a/lib/controllers/actions/oauth2.js
+++ b/lib/controllers/actions/oauth2.js
@@ -47,7 +47,8 @@ module.exports = function (req, res){
       
       var attr = {
         facebookId: _data.id,
-        name: _data.name
+        name: _data.name,
+        email: _data.email
       };
 
       var fieldMap = authConfig.fieldMap || {};


### PR DESCRIPTION
Current Waterlock only stores `facebookId` and `name`. This Pull Request allows the user to define additional fields to store.

Also store the `email` field by default.