### PR TITLE
Use string type for facebookId

### DIFF
--- a/lib/models/auth.js
+++ b/lib/models/auth.js
@@ -5,7 +5,7 @@ var _ = require('lodash');
 exports.attributes = function(attr){
   var template = {
     facebookId: {
-      type: 'float',
+      type: 'string',
       unique: true
     },
     name:{


### PR DESCRIPTION
If the type is float, current fb id number range will cause precision
problem. i.e. Could not select the same id after inserting some fb id
which has like 17 digits.
