### PR TITLE
#9; Facebook fields are not being requested from Graph API properly.

### DIFF
--- a/lib/fboauth2.js
+++ b/lib/fboauth2.js
@@ -133,6 +133,13 @@ FBOAuth2.prototype.get = function(uri, cb){
     cb('Access token does not exist!');
   }
 
-  var url = this._graphAPIURL + uri + '?' + this.toQuery(this.accessToken);
+  var authConfig = require('./waterlock-facebook-auth').authConfig;
+  var fields = [];
+  var fieldMap = authConfig.fieldMap || {};
+  Object.keys(fieldMap).forEach(function(key) { fields.push(fieldMap[key]); });
+  if(fields.indexOf('name') < 0) { fields.push('name'); }
+
+  var url = this._graphAPIURL + uri + '?' + this.toQuery(this.accessToken) + '&fields=' + fields;
+
   request(url, cb);
 };


### PR DESCRIPTION
Fixes #9 by dynamically reading necessary fields from "fieldMap" in the waterlock configuration file, and appending them to the Graph API request.
